### PR TITLE
[KAN-55] fix: align PUID/PGID ownership model and drop user-volume chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pip3 install --break-system-packages --no-cache-dir \
     && beet version
 
 RUN addgroup --system --gid 1001 nodejs \
-    && adduser --system --uid 1001 synthseek \
+    && adduser --system --uid 1001 --ingroup nodejs synthseek \
     && mkdir -p /data/db /data/config /data/logs /data/artwork-cache /downloads /music \
     && chown -R synthseek:nodejs /data /data/artwork-cache /downloads /music
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -18,12 +18,22 @@ echo ""
 
 echo "[1/5] Setting up user permissions..."
 groupmod -o -g "$PGID" nodejs 2>/dev/null || true
-usermod -o -u "$PUID" synthseek 2>/dev/null || true
+usermod -o -u "$PUID" -g "$PGID" synthseek 2>/dev/null || true
 echo "      Done"
 
 echo "[2/5] Creating directories..."
 mkdir -p /data/db /data/config /data/logs /data/artwork-cache /downloads /music
-chown -R synthseek:nodejs /data /app /downloads /music
+chown -R synthseek:nodejs /data /app
+for dir in /downloads /music; do
+    if su-exec synthseek test -w "$dir" 2>/dev/null; then
+        continue
+    fi
+    if su-exec synthseek test -r "$dir" 2>/dev/null; then
+        echo "      $dir: read-only for synthseek (PUID=$PUID). Library will work read-only."
+    else
+        echo "      WARN $dir: synthseek (PUID=$PUID) has no access. Set PUID/PGID to match host owner of $dir, or remount with uid=$PUID,gid=$PGID."
+    fi
+done
 echo "      Done"
 
 echo "[3/5] Loading configuration..."


### PR DESCRIPTION
## Summary

Reported Issue: [#2](https://github.com/arukaraz/synthseek/issues/2)

Ticket: [KAN-55](https://synthseek.atlassian.net/browse/KAN-55)

## Change

**Make synthseek's primary group track PGID** :
- `Dockerfile`: `adduser ... --ingroup nodejs synthseek` so the user's primary group is `nodejs` from creation.
- `start.sh`: `usermod -o -u "$PUID" -g "$PGID" synthseek` to keep it in sync at runtime.
- Verified: files created by synthseek now have `UID:GID = $PUID:$PGID`.

**Drop redundant recursive chown:**
- Keep `chown -R` on `/data` and `/app` (container-managed dirs, typically POSIX).
- Drop `chown -R` on `/downloads` and `/music`. With the primary-group fix above, `su-exec synthseek` writes files with the right `UID:GID` natively — the recursive chown was patching a gap that no longer exists.
- Replace with an access probe (`su-exec synthseek test -r/-w`) emitting boot diagnostics:
  - **Writable** → silent.
  - **Read-only** → info ("Library will work read-only").
  - **No access** → WARN with remediation guidance.